### PR TITLE
Examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if (UNIX)
 endif()
 
 option(TRAVIS_BUILD "Use Travis build configuration" OFF)
+option(PERCY_EXAMPLES "Build examples" ON)
 option(PERCY_TEST "Build tests" OFF)
 option(PERCY_BENCH "Build benchmarks" OFF)
 option(PERCY_BUILD_KITTY "Build kitty for percy" ON)
@@ -85,6 +86,10 @@ if (NOT ${DISABLE_NAUTY})
 endif()
 
 add_subdirectory(include)
+
+if(PERCY_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 if (${PERCY_TEST})
     enable_testing()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB FILENAMES *.cpp)
+
+foreach(filename ${FILENAMES})
+  get_filename_component(basename ${filename} NAME_WE)
+  add_executable(${basename} ${filename})
+  target_link_libraries(${basename} PUBLIC percy)
+endforeach()


### PR DESCRIPTION
This PR adds a directory `examples` to the repository. If the CMake flag `PERCY_EXAMPLES` is set to `true`, all C++ files in `examples` are automatically compiled during the CMake build.

The `examples` directory should remain empty, but allows users to exchange and test code.